### PR TITLE
add license and funder to jupyter book site

### DIFF
--- a/ds_book/_config.yml
+++ b/ds_book/_config.yml
@@ -20,6 +20,12 @@ html:
   use_edit_page_button : true
   use_repository_button: true
   use_issues_button    : true
+  extra_footer: |
+     <p xmlns:cc="http://creativecommons.org/ns#" xmlns:dct="http://purl.org/dc/terms/">
+     <a property="dct:title" rel="cc:attributionURL" 
+      href="https://developmentseed.org/tensorflow-eo-training-2/">Deep Learning with TensorFlow and EO Data</a> was funded by <a property="dct:title" rel="cc:attributionURL"
+      href="https://www.nasa.gov/servir/">NASA SERVIR</a> and is licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">Apache License, Version 2.0<img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://www.apache.org/foundation/press/kit/asf_logo.svg"></a>
+     </p> 
 
 # Interact link settings
 notebook_interface            : "notebook"


### PR DESCRIPTION
Adds the license and funder info as extra HTML footer on landing page.